### PR TITLE
fix: improve consistency and clarity in Simple Domain Allow List POST_LOGIN template

### DIFF
--- a/templates/simple-domain-allowlist-POST_LOGIN/code.js
+++ b/templates/simple-domain-allowlist-POST_LOGIN/code.js
@@ -9,17 +9,20 @@
 exports.onExecutePostLogin = async (event, api) => {
     // ensure user email is present
     if (!event.user.email) {
-        return api.access.deny('Email is invalid');
+        api.access.deny('Email is invalid');
+        return;
     }
 
     // ensure the user has verified their email address
     if (!event.user.email_verified) {
-        return api.access.deny('Email is unverified');
+        api.access.deny('Email is unverified');
+        return;
     }
 
     // ensure the allowed domains are configured
     if (!event.secrets.ALLOWED_DOMAINS) {
-        return api.access.deny('Configuration error');
+        api.access.deny('Configuration error');
+        return;
     }
 
     // parse the allow list of domain and ensure there is at least one
@@ -27,19 +30,21 @@ exports.onExecutePostLogin = async (event, api) => {
         domain.trim().toLowerCase()
     );
     if (!domains) {
-        return api.access.deny('Configuration error');
+        api.access.deny('Configuration error');
+        return;
     }
 
     // ensure a reasonable format for the email
     const splitEMail = event.user.email.split('@');
     if (splitEMail.length !== 2) {
-        return api.access.deny('Email is invalid');
+        api.access.deny('Email is invalid');
+        return;
     }
 
     // if the email domain is not explicitly in our allow list, deny access
     const domain = splitEMail[1].toLowerCase();
     if (!domains.includes(domain)) {
-        return api.access.deny('Email domain is prohibited');
+        api.access.deny('Email domain is prohibited');
     }
 };
 


### PR DESCRIPTION
### Changes

This PR improves code consistency and clarity in `simple-domain-allowlist-POST_LOGIN` template:

- Remove misleading comments about `api.access.deny()` taking a second `userMessage` parameter. This parameter applies to pre-user-registration Actions trigger, not post-login.
    - [Actions Triggers: post-login - API Object](https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-api-object)
    - [Actions Triggers: pre-user-registration - API Object](https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/pre-user-registration-trigger/pre-user-registration-api-object)
- Add missing early `return` statement for consistency. If the lack of `return` was intentional, please let me know.
- Separate combined `return api.access.deny()` statements into distinct lines to clarify the intent of each operation. The return value of `onExecutePostLogin` seems to have no meaning according to the sample codes in the documentation.
    - [Login Trigger](https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger)

### References

-   [ ] I added at least one link to explain why this change is needed.

We discussed this internally, so I don’t have a public link. I thought it would be faster to just write the code and open a PR rather than start a public discussion.

### Testing

**Steps to Reproduce**

1. Test login attempts with users having:
    - Valid and verified email address from allowed domain
    - Valid and verified email address from non-allowed domain
    - Valid and unverified email address from allowed domain
    - Invalid email address
    - Missing email address
1. Confirm that the denial message is displayed and the action execution stops properly for each invalid case

### Checklist

-   [x] I have manually tested any new or updated actions templates in a real auth0 account.
-   [x] This pull request's title matches the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#examples) format
-   [x] This branch is up to date with `main`
-   [x] All existing and new checks complete without errors
-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
-   [x] I have read the [Contribution guide](https://github.com/auth0/opensource-marketplace/blob/main/CONTRIBUTING.md) for this repository
