### PR TITLE
Add CTE to template generator and create template for Skyfire Action- with signed commit

### DIFF
--- a/_templates/generator/template/code.js.CUSTOM_TOKEN_EXCHANGE.t
+++ b/_templates/generator/template/code.js.CUSTOM_TOKEN_EXCHANGE.t
@@ -1,0 +1,13 @@
+---
+to: "<%= trigger == 'CUSTOM_TOKEN_EXCHANGE' ? `templates/${fileName}-${trigger}/code.js` : null %>"
+---
+
+/**
+* Handler to be executed while executing a custom token exchange request
+* @param {Event} event - Details about the incoming token exchange request.
+* @param {CustomTokenExchangeAPI} api - Methods and utilities to define token exchange process.
+*/
+exports.onExecuteCustomTokenExchange = async (event, api) => {
+  // Code goes here
+  return;
+};

--- a/_templates/generator/template/manifest.yaml.t
+++ b/_templates/generator/template/manifest.yaml.t
@@ -10,7 +10,7 @@ useCases:
 public: true
 description: "<%= description %>"
 version: "1.0.0"
-runtime: "node18"
+runtime: "node22"
 sourceUrl: "https://github.com/auth0/opensource-marketplace/tree/main/templates/<%= fileName %>-<%= trigger %>/manifest.yaml"
 notes: ""
 

--- a/_templates/generator/template/prompt.js
+++ b/_templates/generator/template/prompt.js
@@ -9,6 +9,7 @@ const TRIGGERS = [
     'POST_CHANGE_PASSWORD',
     'SEND_PHONE_MESSAGE',
     'PASSWORD_RESET_POST_CHALLENGE',
+    'CUSTOM_TOKEN_EXCHANGE',
 ];
 
 module.exports = {

--- a/scripts/templates/validate-templates.js
+++ b/scripts/templates/validate-templates.js
@@ -14,6 +14,7 @@ const IntegrationTrigger = [
     'POST_CHANGE_PASSWORD',
     'SEND_PHONE_MESSAGE',
     'PASSWORD_RESET_POST_CHALLENGE',
+    'CUSTOM_TOKEN_EXCHANGE',
 ];
 
 const UseCase = [

--- a/templates/skyfire-token-exchange-CUSTOM_TOKEN_EXCHANGE/code.js
+++ b/templates/skyfire-token-exchange-CUSTOM_TOKEN_EXCHANGE/code.js
@@ -1,0 +1,136 @@
+const { jwtVerify, createRemoteJWKSet } = require('jose');
+var validator = require('validator');
+
+// Action Config (dependent on client setup)
+const DB_NAME = '{{YOUR_CONNECTION_NAME}}'; // Auth0 DB connection
+
+// Skyfire verification details
+const JWKS_URL = 'https://app.skyfire.xyz/.well-known/jwks.json'; // Skyfire jwks url
+const JWT_ISSUER = 'https://app.skyfire.xyz'; // skyfire domain
+
+/**
+ * Handler to be executed while executing a custom token exchange request
+ * @param {Event} event - Details about the incoming token exchange request.
+ * @param {CustomTokenExchangeAPI} api - Methods and utilities to define token exchange process.
+ */
+exports.onExecuteCustomTokenExchange = async (event, api) => {
+    const subject_token = event.transaction.subject_token; // Skyfire token
+
+    // Token validation starts
+    const JWKS = createRemoteJWKSet(new URL(JWKS_URL));
+
+    let decodedPayload = null;
+
+    try {
+        const { payload, protectedHeader } = await jwtVerify(
+            subject_token,
+            JWKS,
+            {
+                issuer: JWT_ISSUER,
+                algorithms: ['ES256'],
+            }
+        );
+
+        if (!['kya+JWT', 'kya+pay+JWT'].includes(protectedHeader.typ)) {
+            console.log('Invalid typ:', protectedHeader.typ);
+            return api.access.deny(
+                'invalid_typ',
+                'typ should be one of kya+JWT or kya+pay+JWT'
+            );
+        }
+
+        decodedPayload = payload;
+    } catch (err) {
+        console.log('JWT verification failed:', err.message || err);
+        return api.access.deny(
+            'invalid_token',
+            'JWT verification failed: invalid token.'
+        );
+    }
+
+    // JWT successfully verified, now verify skyfireEmail
+    const isEmailValid = validator.isEmail(decodedPayload.bid.skyfireEmail);
+
+    if (!isEmailValid) {
+        console.log('Invalid email format');
+        return api.access.deny('invalid_email', 'Invalid email format.');
+    }
+
+    // Validate env is 'production'
+    if (decodedPayload.env !== 'production') {
+        console.log('Invalid environment:', decodedPayload.env);
+        return api.access.deny(
+            'invalid_env',
+            'Token is not from production environment.'
+        );
+    }
+
+    const now = Math.floor(Date.now() / 1000); // current time in seconds
+
+    // Validate iat is in the past
+    if (typeof decodedPayload.iat !== 'number' || decodedPayload.iat > now) {
+        console.log('Invalid iat:', decodedPayload.iat);
+        return api.access.deny(
+            'invalid_iat',
+            'Issued-at time is in the future or missing.'
+        );
+    }
+
+    // Validate exp is now or in the future
+    if (typeof decodedPayload.exp !== 'number' || decodedPayload.exp <= now) {
+        console.log('Token has expired:', decodedPayload.exp);
+        return api.access.deny('token_expired', 'Token has expired.');
+    }
+
+    // Validate jti is a UUID
+    if (!validator.isUUID(decodedPayload.jti)) {
+        console.log('Invalid jti:', decodedPayload.jti);
+        return api.access.deny(
+            'invalid_jti',
+            'Invalid token ID (jti): not a valid UUID.'
+        );
+    }
+
+    // Validate sub is a UUID
+    if (!validator.isUUID(decodedPayload.sub)) {
+        console.log('Invalid sub:', decodedPayload.sub);
+        return api.access.deny(
+            'invalid_sub',
+            'Invalid subject (sub): not a valid UUID.'
+        );
+    }
+
+    // Validate aud is a UUID
+    if (!validator.isUUID(decodedPayload.aud)) {
+        console.log('Invalid aud:', decodedPayload.aud);
+        return api.access.deny(
+            'invalid_aud',
+            'Invalid audience (aud): not a valid UUID.'
+        );
+    }
+
+    // Token validation ends
+
+    // Mapping Skyfire token to Auth0 user
+    api.authentication.setUserByConnection(
+        DB_NAME, // Auth0 DB connection
+        {
+            user_id: decodedPayload.sub,
+            email: decodedPayload.bid.skyfireEmail,
+            email_verified: true,
+            given_name: decodedPayload.bid.nameFirst,
+            family_name: decodedPayload.bid.nameLast,
+            username: decodedPayload.bid.skyfireEmail,
+            name:
+                decodedPayload.bid.nameFirst +
+                ' ' +
+                decodedPayload.bid.nameLast,
+            nickname: decodedPayload.bid.nameFirst,
+            verify_email: false,
+        },
+        {
+            creationBehavior: 'create_if_not_exists',
+            updateBehavior: 'none',
+        }
+    );
+};

--- a/templates/skyfire-token-exchange-CUSTOM_TOKEN_EXCHANGE/manifest.yaml
+++ b/templates/skyfire-token-exchange-CUSTOM_TOKEN_EXCHANGE/manifest.yaml
@@ -1,0 +1,12 @@
+id: '5ad0a454-5431-4689-817f-c32d6a21c493'
+name: 'Skyfire token exchange'
+triggers:
+    - 'CUSTOM_TOKEN_EXCHANGE'
+useCases:
+    - 'ACCESS_CONTROL'
+public: true
+description: 'Custom Token Exchange Action to securely exchange Skyfire tokens for Auth0 tokens'
+version: '1.0.0'
+runtime: 'node22'
+sourceUrl: 'https://github.com/auth0/opensource-marketplace/tree/main/templates/skyfire-token-exchange-CUSTOM_TOKEN_EXCHANGE/manifest.yaml'
+notes: 'Add YOUR_CONNECTION_NAME when deploying the Action'


### PR DESCRIPTION
### Changes

The objective of this PR is to test adding support for Actions Templates for the Custom Token Exchange trigger. 

Changes:
- CUSTOM_TOKEN_EXCHANGE added to the template generator
- a specific Action Template named Skyfire is added, to enable testing the end-to-end

The proposed template for the Skyfire Actions is not the final code but I need to test we are actually able to create Action templates that actually work for this new trigger. We will be able to update the Skyfire template code later.

### References
- https://auth0.com/docs/authenticate/custom-token-exchange
- https://auth0.slack.com/archives/CT68Z3273/p1754498203858769 

### Testing
The main objective is testing an Action Template is correctly offered to customers in the Dashboard to instantiate a valid Action associated to the Custom Token Exchange trigger. I can help test testing the instantiated Action works.

### Checklist

-   [ ] I have manually tested any new or updated actions templates in a real auth0 account.
-   [ ] This pull request's title matches the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#examples) format
-   [ ] This branch is up to date with `main`
-   [ ] All existing and new checks complete without errors
-   [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
-   [ ] I have read the [Contribution guide](https://github.com/auth0/opensource-marketplace/blob/main/CONTRIBUTING.md) for this repository
