### PR TITLE
doc: update outbound SCIM template documentation link

### DIFF
--- a/templates/outbound-scim-EVENT_STREAM/code.js
+++ b/templates/outbound-scim-EVENT_STREAM/code.js
@@ -9,7 +9,7 @@
  * userName search when a destination rejects externalId filtering.
  *
  * Setup and how it works:
- * https://auth0.com/docs/customize/events/orchestrate-business-workflows#set-up-scim-provisioning
+ * https://auth0.com/docs/customize/events/send-outbound-scim
  *
  * BEFORE YOU SAVE: add these Action Secrets (Secrets panel, key icon).
  *   REQUIRED


### PR DESCRIPTION
### Changes

Updating the link to the final Outbound SCIM Template documentation.

-   [x] I described the changes in this PR.

### References

The previous link was a placeholder for a different SCIM-related documentation.
The final document address is: https://auth0.com/docs/customize/events/send-outbound-scim

-   [x] I added at least one link to explain why this change is needed.

### Testing

After the document is released, the link should work.

### Checklist

-   [x] I have manually tested any new or updated actions templates in a real auth0 account.
-   [x] This pull request's title matches the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#examples) format
-   [x] This branch is up to date with `main`
-   [x] All existing and new checks complete without errors
-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
-   [x] I have read the [Contribution guide](https://github.com/auth0/opensource-marketplace/blob/main/CONTRIBUTING.md) for this repository
